### PR TITLE
Allow contrasena alias and include auth headers

### DIFF
--- a/controllers/usuariosController.js
+++ b/controllers/usuariosController.js
@@ -11,14 +11,15 @@ exports.listarUsuarios = (req, res) => {
 };
 
 exports.crearUsuario = async (req, res) => {
-  const { nombre, email, contraseña, rol } = req.body;
+  const { nombre, email, rol, contraseña, contrasena } = req.body;
+  const pass = contraseña || contrasena;
 
-  if (!nombre || !email || !contraseña || !rol) {
+  if (!nombre || !email || !pass || !rol) {
     return res.status(400).json({ error: 'Faltan datos obligatorios' });
   }
 
   try {
-    const contraseñaHasheada = await bcrypt.hash(contraseña, 10);
+    const contraseñaHasheada = await bcrypt.hash(pass, 10);
 
     const sql = 'INSERT INTO usuarios (nombre, email, contraseña, rol) VALUES (?, ?, ?, ?)';
     db.query(sql, [nombre, email, contraseñaHasheada, rol], (err, resultado) => {

--- a/frontend/src/components/UsuariosPanel.tsx
+++ b/frontend/src/components/UsuariosPanel.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+
+const UsuariosPanel: React.FC = () => {
+  const [nombre, setNombre] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [rol, setRol] = useState('');
+
+  const token = localStorage.getItem('token');
+
+  const crearUsuario = async () => {
+    await fetch('/api/usuarios', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        nombre,
+        email,
+        contraseña: password,   // clave exacta
+        rol,
+      }),
+    });
+  };
+
+  return (
+    <div>
+      {/* UI elements would go here */}
+      <button onClick={crearUsuario}>Crear usuario</button>
+    </div>
+  );
+};
+
+export default UsuariosPanel;


### PR DESCRIPTION
## Summary
- send user creation requests with JSON body and auth token
- accept `contrasena` fallback for password

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68a4d889c1c8832a89f8d3791e642010